### PR TITLE
Add support for v2.0.0rc1 model

### DIFF
--- a/Properties.yaml
+++ b/Properties.yaml
@@ -1,61 +1,59 @@
 ---
 schemas:
   Catalog:
-  - "Catalog.ttl"
-  - "Agent.ttl"
-  - "Kind.ttl"
-  - "PeriodOfTime.ttl"
+    - "Catalog.ttl"
+    - "Agent.ttl"
+    - "Kind.ttl"
+    - "PeriodOfTime.ttl"
   Dataset:
-  - "Dataset.ttl"
-  - "Agent.ttl"
-  - "Kind.ttl"
-  - "PeriodOfTime.ttl"
+    - "Dataset.ttl"
+    - "Agent.ttl"
+    - "Kind.ttl"
+    - "PeriodOfTime.ttl"
+    - "Attribution.ttl"
+    - "Identifier.ttl"
+    - "QualityCertificate.ttl"
+    - "Relationship.ttl"
   Dataset Series:
-  - "DatasetSeries.ttl"
-  - "Agent.ttl"
-  - "Kind.ttl"
+    - "DatasetSeries.ttl"
+    - "Agent.ttl"
+    - "Kind.ttl"
   Resource:
-  - "Resource.ttl"
+    - "Resource.ttl"
   Distribution:
-  - "Distribution.ttl"
-  - "PeriodOfTime.ttl"
-  - "Checksum.ttl"
-  Project:
-  - "Project.ttl"
-  - "Agent.ttl"
-  Study:
-  - "Study.ttl"
+    - "Distribution.ttl"
+    - "PeriodOfTime.ttl"
+    - "Checksum.ttl"
   Data Service:
-  - "DataService.ttl"
-  - "Agent.ttl"
-  - "Kind.ttl"
+    - "DataService.ttl"
+    - "Agent.ttl"
+    - "Kind.ttl"
 parentChild:
   Resource:
-  - "Dataset"
-  - "Catalog"
-  - "Data Service"
-  - "Project"
-  - "Study"
+    - "Dataset"
+    - "Catalog"
+    - "Data Service"
 resources:
-  Project:
-    parentResource: "FAIR Data Point"
-    parentRelationIri: "http://www.example.com/project"
-  Study:
-    parentResource: "Project"
-    parentRelationIri: "http://www.example.com/study"
   Dataset Series:
-    parentResource: "FAIR Data Point"
-    parentRelationIri: "http://www.example.com/study"
-inputDir: "https://raw.githubusercontent.com/Health-RI/health-ri-metadata/v2.0.0-beta.2/Formalisation(shacl)/Core/PiecesShape/"
+    schema: "Dataset Series"
+    parentResource: "Dataset"
+    parentRelationIri: "http://www.w3.org/ns/dcat#inSeries"
+  Sample Distribution:
+    schema: "Distribution"
+    parentResource: "Dataset"
+    parentRelationIri: "http://www.w3.org/ns/adms#sample"
+  Analytics Distribution:
+    schema: "Distribution"
+    parentResource: "Dataset"
+    parentRelationIri: "http://healthdataportal.eu/ns/health#analytics"
+inputDir: "https://raw.githubusercontent.com/Health-RI/health-ri-metadata/develop/Formalisation(shacl)/Core/PiecesShape/"
 outputDir: "C:\\Users\\PatrickDekker(Health\\IdeaProjects\\health-ri-metadata\\Formalisation(shacl)\\\
   Core\\FairDataPointShape"
 schemasToPublish:
-- "Resource"
-- "Catalog"
-- "Dataset"
-- "Dataset Series"
-- "Distribution"
-- "Data Service"
-- "Project"
-- "Study"
+  - "Resource"
+  - "Catalog"
+  - "Dataset"
+  - "Dataset Series"
+  - "Distribution"
+  - "Data Service"
 schemaVersion: "2.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,14 @@
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>
                 <artifactId>rdf4j-bom</artifactId>
-                <version>5.1.2</version>
+                <version>5.1.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.18.3</version> <!-- Use the latest version available -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -29,16 +36,38 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-rio-turtle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.14</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -57,10 +86,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <!--            version should be same as used in Rdf4j-->
-            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/nl/healthri/fdp/uploadschema/FDP.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/FDP.java
@@ -1,7 +1,6 @@
 package nl.healthri.fdp.uploadschema;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.healthri.fdp.uploadschema.requestbodies.*;
 import nl.healthri.fdp.uploadschema.requestresponses.*;
@@ -84,7 +83,7 @@ public class FDP implements AutoCloseable {
     }
 
     public ResourceMap fetchResourceFromFDP() {
-        logger.info("Fetch schema info from fdp");
+        logger.info("Fetch resource info from fdp");
         ResourceResponse[] resources = request().setUri(url + "/resource-definitions")
                 .setToken(token).get(ResourceResponse[].class);
 
@@ -122,33 +121,11 @@ public class FDP implements AutoCloseable {
             rr.children().add(child);
         }
 
-//        prettyPrint(rr);
-        //copy ResourceResponse to ResourceParms, when you look at the consule of the webclient
-        //it looks like the ResourceResponse class is used as parameter instead of ResourceParms class!
-
-//        var rpChild = rr.children().stream().map(c -> new ResourceParms.ResourceChild(c.resourceDefinitionUuid())).toList();
-//        var rpExternalLink = rr.externalLinks().stream().map(el -> new ResourceParms.ResourceLink(el.title(), el.propertyUri())).toList();
-//
-//        ResourceParms rp = new ResourceParms(task.resource,
-//                task.url(),
-//                rr.metadataSchemaUuids(),
-//                rr.targetClassUris(),
-//                new ArrayList<>(rpChild),
-//                new ArrayList<>(rpExternalLink));
         logger.info("update resource {} on the fdp", task.resource);
         request().setToken(token)
                 .setUri(url("resource-definitions", task.UUID))
                 .setBody(rr)
                 .put(ResourceResponse.class);
-    }
-
-    private void prettyPrint(Object o) {
-        try {
-            System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(o));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
     }
 
     /**
@@ -203,7 +180,7 @@ public class FDP implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (client != null) {
             client.close();
         }

--- a/src/main/java/nl/healthri/fdp/uploadschema/SchemaTools.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/SchemaTools.java
@@ -51,7 +51,7 @@ public class SchemaTools implements Runnable {
             if (command == CommandEnum.FILES) {
                 logger.info("Writing files: {}", p.getFiles().keySet());
                 for (var e : p.getFiles().entrySet()) {
-                    File file = new File(p.outputDir, e.getKey() + ".ttl");
+                    File file = new File(p.outputDir, e.getKey().replaceAll(" ", "") + ".ttl");
                     Model m = RdfUtils.readFiles(e.getValue());
                     RdfUtils.safeModel(file, m);
                 }
@@ -79,7 +79,7 @@ public class SchemaTools implements Runnable {
                     resourceTasks.stream().filter(ResourceUpdateInsertTask::isInsert).forEach(fdp::insertResource);
 
                     if (resourceTasks.stream().noneMatch(not(ResourceUpdateInsertTask::isInsert))) {
-                        logger.warn("Updating resources is not supported yet, but will try to add childeren if needed)");
+                        logger.warn("Updating resources is not supported yet, but will try to add children if needed)");
                     }
 
                     //add the previous resources as child to parent.

--- a/src/main/java/nl/healthri/fdp/uploadschema/tasks/ResourceUpdateInsertTask.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/tasks/ResourceUpdateInsertTask.java
@@ -43,14 +43,14 @@ public class ResourceUpdateInsertTask {
     public static List<ResourceUpdateInsertTask> createTask(Properties p, FDP fdp) {
         var resourcesOnFdp = fdp.fetchResourceFromFDP();
         var shapesOnFdp = fdp.fetchSchemaFromFDP();
-        return p.resources.keySet().stream().map(r -> new ResourceUpdateInsertTask(r)
+        return p.resources.entrySet().stream().map(r -> new ResourceUpdateInsertTask(r.getKey())
                 .addExistingInfo(resourcesOnFdp)
-                .addShapeUUID(shapesOnFdp)).toList();
+                .addShapeUUID(shapesOnFdp, r.getValue().schema())).toList();
     }
 
     public String pluralName() {
         //FIXME shape datasetSeries is already plural form.
-        if (childName.toLowerCase().endsWith("series")) return childName;
+        if (childName.toLowerCase().endsWith("ies")) return childName;
 
         // Rule 1: Words ending in consonant + "y" -> replace "y" with "ies"
         if (Pattern.matches(".*[^aeiou]y$", childName)) {
@@ -66,8 +66,9 @@ public class ResourceUpdateInsertTask {
         }
     }
 
-    public ResourceUpdateInsertTask addShapeUUID(ShapesMap shapes) {
-        var shape = shapes.getUUID(resource);
+    public ResourceUpdateInsertTask addShapeUUID(ShapesMap shapes, String schema) {
+        String name = schema.isBlank() ? resource : schema;
+        var shape = shapes.getUUID(name);
         shape.ifPresentOrElse(s -> shapeUUUID = s,
                 () -> logger.error("Can't find shape: {} ", resource));
         return this;

--- a/src/main/java/nl/healthri/fdp/uploadschema/tasks/ShapeUpdateInsertTask.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/tasks/ShapeUpdateInsertTask.java
@@ -35,7 +35,6 @@ public class ShapeUpdateInsertTask {
         var shapesOnFdp = fdp.fetchSchemaFromFDP();
         logger.info("found following shapes on fdp: {}", shapesOnFdp.keySet());
 
-
         //list of the task we have to do for insert/updating shacls
         return Shapes.stream().map(r -> {
             var ShapeUpdateInsertTask = new ShapeUpdateInsertTask(r);

--- a/src/main/java/nl/healthri/fdp/uploadschema/utils/Properties.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/utils/Properties.java
@@ -30,8 +30,8 @@ public class Properties {
     /**
      * You can run this class to create a default Propertie.yaml. it will overwrite existing one!
      *
-     * @param args
-     * @throws IOException
+     * @param args arguments are ignored.
+     * @throws IOException when properties can't be written.
      */
     public static void main(String[] args) throws IOException {
         var p = new Properties();
@@ -55,11 +55,10 @@ public class Properties {
 
         //this is list schema to publish, Make sure Parents are places first in the list(!)
         p.schemasToPublish = List.of("Resource", "Catalog", "Dataset", "Dataset Series", "Distribution", "Data Service", "Project", "Study");
-        p.addResourceDescription("Project", "FAIR Data Point", "http://www.example.com/project");
-        p.addResourceDescription("Study", "Project", "http://www.example.com/study");
-        p.addResourceDescription("Dataset Series", "FAIR Data Point", "http://www.example.com/study");
+        p.addResourceDescription("Dataset Series", "Dataset", "http://www.w3.org/ns/dcat#inSeries", "Dataset Series");
+        p.addResourceDescription("Sample Distribution", "Dataset", "http://www.w3.org/ns/adms#sample", "Distribution");
+        p.addResourceDescription("Analytics Distribution", "Dataset", "http://healthdataportal.eu/ns/health#analytics", "Distribution");
         p.schemaVersion = "2.0.0";
-
 
         var mapper = new ObjectMapper(new YAMLFactory());
         mapper.writeValue(new File("Properties.yaml"), p);
@@ -83,8 +82,8 @@ public class Properties {
         schemas.put(target, List.of(files));
     }
 
-    public void addResourceDescription(String name, String parentResource, String parentLinkIRI) {
-        resources.put(name, new ResourceProperties(parentResource, parentLinkIRI));
+    public void addResourceDescription(String name, String parentResource, String parentLinkIRI, String schema) {
+        resources.put(name, new ResourceProperties(parentResource, parentLinkIRI, schema));
     }
 
     public void addParent(String parent, String... children) {
@@ -111,7 +110,8 @@ public class Properties {
 
     public record ResourceProperties(
             String parentResource,
-            String parentRelationIri) {
+            String parentRelationIri,
+            String schema) {
     }
 }
 

--- a/src/main/java/nl/healthri/fdp/uploadschema/utils/RequestBuilder.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/utils/RequestBuilder.java
@@ -11,7 +11,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Optional;
 
 public class RequestBuilder {
 
@@ -21,7 +20,7 @@ public class RequestBuilder {
     private final HttpClient client;
 
     private String body = "";
-    private Optional<String> bearer = Optional.empty();
+    private String bearer = "";
     private URI uri = null;
 
     public RequestBuilder(ObjectMapper mapper, HttpClient client) {
@@ -61,7 +60,7 @@ public class RequestBuilder {
     }
 
     public RequestBuilder setToken(TokenResponse token) {
-        this.bearer = token == null ? Optional.empty() : Optional.of(token.asHeaderString());
+        this.bearer = token == null ? "" : token.asHeaderString();
         return this;
     }
 
@@ -89,8 +88,8 @@ public class RequestBuilder {
             var b = builder
                     .header("accept", "application/json")
                     .header("Content-Type", "application/json");
-            var request = bearer.isPresent() ?
-                    b.header("Authorization", bearer.get()).build()
+            var request = !bearer.isBlank() ?
+                    b.header("Authorization", bearer).build()
                     : b.build();
 
             logger.debug("body: {}", body);
@@ -104,6 +103,7 @@ public class RequestBuilder {
             }
             throw new RuntimeException("Invalid request: " + response.statusCode() + " -> " + response.body());
         } catch (IOException e) {
+            logger.error("url: {}", uri.toString());
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();//


### PR DESCRIPTION
- Updated dependencies, don't use Jackon Json libs from Rdf4j but include latest from maven directly
- Update property files to reflect v2 of the model
- Set schema name explicitly for resource, instead of using resource name as schema name.
- some code cleanup
- fixed some compile warnings about Optional<String> field