### PR TITLE
chore: use java version 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.organization>health-ri</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Download graded to java 17 because the github action is running on java 17.