### PR TITLE
chore: remove unused spring dependency and usage

### DIFF
--- a/src/main/java/nl/healthri/fdp/uploadschema/integrations/FdpClient.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/integrations/FdpClient.java
@@ -1,26 +1,23 @@
 package nl.healthri.fdp.uploadschema.integrations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import nl.healthri.fdp.uploadschema.domain.ResourceTask;
 import nl.healthri.fdp.uploadschema.domain.ShapeTask;
+import nl.healthri.fdp.uploadschema.dto.auth.LoginRequestDto;
+import nl.healthri.fdp.uploadschema.dto.auth.LoginResponseDto;
 import nl.healthri.fdp.uploadschema.dto.resource.ResourceRequestDto;
+import nl.healthri.fdp.uploadschema.dto.resource.ResourceResponseDto;
 import nl.healthri.fdp.uploadschema.dto.schema.ReleaseSchemaRequestDto;
+import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
 import nl.healthri.fdp.uploadschema.dto.schema.UpdateSchemaRequestDto;
 import nl.healthri.fdp.uploadschema.dto.settings.SettingsRequestDto;
 import nl.healthri.fdp.uploadschema.dto.settings.SettingsResponseDto;
-import nl.healthri.fdp.uploadschema.dto.auth.LoginRequestDto;
-import nl.healthri.fdp.uploadschema.dto.resource.ResourceResponseDto;
-import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
-import nl.healthri.fdp.uploadschema.dto.auth.LoginResponseDto;
 import nl.healthri.fdp.uploadschema.integrations.exceptions.FdpClientException;
 import nl.healthri.fdp.uploadschema.utils.HttpRequestUtils;
-
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.net.URI;
@@ -28,9 +25,9 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 
-@Component
 public class FdpClient implements FdpClientInterface {
     private final HttpClient client;
     private final URI hostname;

--- a/src/main/java/nl/healthri/fdp/uploadschema/services/FdpService.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/services/FdpService.java
@@ -1,38 +1,36 @@
 package nl.healthri.fdp.uploadschema.services;
 
 import nl.healthri.fdp.uploadschema.config.fdp.Settings;
-import nl.healthri.fdp.uploadschema.domain.Version;
 import nl.healthri.fdp.uploadschema.domain.ResourceTask;
 import nl.healthri.fdp.uploadschema.domain.ShapeTask;
+import nl.healthri.fdp.uploadschema.domain.Version;
+import nl.healthri.fdp.uploadschema.dto.auth.LoginRequestDto;
+import nl.healthri.fdp.uploadschema.dto.auth.LoginResponseDto;
 import nl.healthri.fdp.uploadschema.dto.resource.ResourceRequestDto;
+import nl.healthri.fdp.uploadschema.dto.resource.ResourceResponseDto;
 import nl.healthri.fdp.uploadschema.dto.schema.ReleaseSchemaRequestDto;
+import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
 import nl.healthri.fdp.uploadschema.dto.schema.UpdateSchemaRequestDto;
 import nl.healthri.fdp.uploadschema.dto.settings.SettingsRequestDto;
 import nl.healthri.fdp.uploadschema.dto.settings.SettingsResponseDto;
-import nl.healthri.fdp.uploadschema.dto.auth.LoginRequestDto;
-import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
-import nl.healthri.fdp.uploadschema.dto.auth.LoginResponseDto;
 import nl.healthri.fdp.uploadschema.integrations.FdpClientInterface;
 import nl.healthri.fdp.uploadschema.integrations.exceptions.FdpClientException;
 import nl.healthri.fdp.uploadschema.utils.SchemaInfo;
-import nl.healthri.fdp.uploadschema.dto.resource.ResourceResponseDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static nl.healthri.fdp.uploadschema.config.fdp.Settings.*;
+import static nl.healthri.fdp.uploadschema.config.fdp.Settings.convertToEntity;
 
-
-@Service
 public class FdpService implements FdpServiceInterface {
     private final FdpClientInterface fdpClient;
 
     private static final Logger logger = LoggerFactory.getLogger(FdpService.class);
 
-    @Autowired
     public FdpService(FdpClientInterface fdpClient) {
         this.fdpClient = fdpClient;
     }

--- a/src/main/java/nl/healthri/fdp/uploadschema/services/ResourceTaskService.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/services/ResourceTaskService.java
@@ -1,12 +1,11 @@
 package nl.healthri.fdp.uploadschema.services;
 
+import nl.healthri.fdp.uploadschema.config.fdp.Properties;
 import nl.healthri.fdp.uploadschema.domain.ResourceTask;
 import nl.healthri.fdp.uploadschema.dto.resource.ResourceResponseDto;
 import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
-import nl.healthri.fdp.uploadschema.config.fdp.Properties;
 import nl.healthri.fdp.uploadschema.utils.ResourceInfo;
 import nl.healthri.fdp.uploadschema.utils.SchemaInfo;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
@@ -14,7 +13,6 @@ import java.util.Map;
 import static nl.healthri.fdp.uploadschema.utils.ResourceInfo.createResourceInfoMap;
 import static nl.healthri.fdp.uploadschema.utils.SchemaInfo.createSchemaInfoMap;
 
-@Service
 public class ResourceTaskService implements  ResourceTaskServiceInterface {
     public FdpServiceInterface fdpService;
     public Properties properties;

--- a/src/main/java/nl/healthri/fdp/uploadschema/services/SchemaToolService.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/services/SchemaToolService.java
@@ -1,15 +1,14 @@
 package nl.healthri.fdp.uploadschema.services;
 
+import nl.healthri.fdp.uploadschema.config.fdp.Properties;
 import nl.healthri.fdp.uploadschema.domain.ResourceTask;
 import nl.healthri.fdp.uploadschema.domain.ShapeTask;
 import nl.healthri.fdp.uploadschema.utils.FileHandler;
-import nl.healthri.fdp.uploadschema.config.fdp.Properties;
 import nl.healthri.fdp.uploadschema.utils.RdfUtils;
 import nl.healthri.fdp.uploadschema.utils.XlsToRdfUtils;
 import org.eclipse.rdf4j.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,7 +18,6 @@ import java.util.List;
 
 import static java.util.function.Predicate.not;
 
-@Service
 public class SchemaToolService implements SchemaToolServiceInterface {
     public FdpServiceInterface fdpService;
     public ResourceTaskServiceInterface resourceTaskService;

--- a/src/main/java/nl/healthri/fdp/uploadschema/services/ShapeTaskService.java
+++ b/src/main/java/nl/healthri/fdp/uploadschema/services/ShapeTaskService.java
@@ -1,22 +1,21 @@
 package nl.healthri.fdp.uploadschema.services;
 
-import nl.healthri.fdp.uploadschema.domain.Version;
+import nl.healthri.fdp.uploadschema.config.fdp.Properties;
 import nl.healthri.fdp.uploadschema.domain.ShapeTask;
+import nl.healthri.fdp.uploadschema.domain.Version;
 import nl.healthri.fdp.uploadschema.domain.enums.ShapeStatus;
 import nl.healthri.fdp.uploadschema.dto.schema.SchemaDataResponseDto;
-import nl.healthri.fdp.uploadschema.utils.*;
-import nl.healthri.fdp.uploadschema.config.fdp.Properties;
+import nl.healthri.fdp.uploadschema.utils.FileHandler;
+import nl.healthri.fdp.uploadschema.utils.RdfUtils;
+import nl.healthri.fdp.uploadschema.utils.SchemaInfo;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.Models;
-import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.util.*;
-import java.util.List;
 
 import static nl.healthri.fdp.uploadschema.utils.SchemaInfo.createSchemaInfoMap;
 
-@Service
 public class ShapeTaskService implements  ShapeTaskServiceInterface {
     public FdpServiceInterface fdpService;
     public FileHandler fileHandler;


### PR DESCRIPTION
Spring was referenced but not _used_ used. For future work: this is the output of `mvn dependency:analyze -DignoreNonCompile=true`

```bash
[INFO] --- dependency:3.7.0:analyze (default-cli) @ FairDataPointSchemaTool ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.eclipse.rdf4j:rdf4j-model-api:jar:5.3.1:compile
[WARNING]    org.eclipse.rdf4j:rdf4j-repository-api:jar:5.3.1:compile
[WARNING]    org.eclipse.rdf4j:rdf4j-model:jar:5.3.1:compile
[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[WARNING]    org.eclipse.rdf4j:rdf4j-sail-api:jar:5.3.1:compile
[WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.9.3:test
[WARNING]    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
[WARNING]    org.eclipse.rdf4j:rdf4j-rio-api:jar:5.3.1:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.apache.poi:poi-ooxml-schemas:jar:4.1.2:compile
[WARNING]    ch.qos.logback:logback-core:jar:1.5.32:compile
[WARNING]    org.modelmapper:modelmapper:jar:3.2.6:compile
[WARNING]    org.apache.poi:poi-ooxml:jar:5.5.1:compile
```

The 'unused declared' could be removed as well (after thorough testing).