### PR TITLE
chore: remove unused Spring Boot dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <xls2rdf.version>3.2.1</xls2rdf.version>
         <poi.version>5.5.1</poi.version>
         <poi-ooxml.version>4.1.2</poi-ooxml.version>
-        <spring-boot.version>4.1.0</spring-boot.version>
         <modelmapper.version>3.2.6</modelmapper.version>
         
         <junit-jupiter.version>6.1.2</junit-jupiter.version>
@@ -107,13 +106,6 @@
             <artifactId>poi-ooxml-schemas</artifactId>
             <version>${poi-ooxml.version}</version>
         </dependency>
-        <!-- Spring Boot starter (includes @Service, @Autowired, etc.) -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>


### PR DESCRIPTION
## Summary
- `spring-boot-starter` was declared in `pom.xml` but never actually used — no `org.springframework` imports or Spring annotations (`@Service`, `@Autowired`, `@Component`, etc.) exist anywhere in the codebase.
- Removes the dependency and its `spring-boot.version` property.

## Test plan
- [x] `mvn compile` succeeds with no errors after removal