### PR TITLE
fix: upgrade Alpine packages to patch p11-kit CVE-2026-2100

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn -q package -DskipTests=true
 
 FROM eclipse-temurin:26-jre-alpine-3.23
 
-RUN apk add --no-cache expat=2.8.1-r0
+RUN apk upgrade --no-cache
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
## Summary
- Runtime base image (`eclipse-temurin:26-jre-alpine-3.23`) ships `p11-kit`/`p11-kit-trust` 0.25.5-r2, vulnerable to CVE-2026-2100.
- Replaced the single `expat` version pin with `apk upgrade --no-cache`, which patches p11-kit (and expat, freetype, tzdata) to their fixed versions.
- Dropping the exact pin also avoids needing manual version bumps for future Alpine security patches inside the Dockerfile.

## Test plan
- [x] Verified via `docker run` against the base image that `apk upgrade --no-cache` exits 0 and upgrades `p11-kit`/`p11-kit-trust` to `0.26.2-r0`.